### PR TITLE
ETL await Search/alternative entrypoint

### DIFF
--- a/etl/Dockerfile
+++ b/etl/Dockerfile
@@ -2,10 +2,9 @@ FROM python:3-alpine
 RUN pip install --no-cache-dir pip==18.0
 RUN apk add --update git gcc libc-dev libxslt-dev
 RUN pip install --no-cache-dir pipenv
-COPY src/Pipfile /data/Pipfile
 WORKDIR /data/
+COPY src/Pipfile Pipfile
 RUN pipenv --three install
-COPY src/ /data/
-WORKDIR /data/
+COPY src/ .
 ENTRYPOINT [ "pipenv", "run" ]
 CMD [ "python", "main.py" ]

--- a/etl/src/config.json
+++ b/etl/src/config.json
@@ -1,7 +1,10 @@
 {
-    "arango": {
+    "dbms": {
         "arangoURL": "http://dbms:8529",
         "username": "root",
         "password": "tdm"
+    },
+    "search": {
+        "searchURL": "http://search:9200"
     }
 }

--- a/etl/src/main.py
+++ b/etl/src/main.py
@@ -82,7 +82,7 @@ def main():
         populate_snmp(db)
         logging.info('Populating YANG data.')
         populate_yang(db)
-    if created or args.stage == 'etl':
+    if created or args.stage == 'search':
         logging.info('Populating search database with parsed data.')
         populate_search(db)
     logging.info('ETL process complete!')
@@ -93,7 +93,7 @@ def setup_args():
     )
     parser.add_argument('--stage',
         nargs='?',
-        help='None | etl',
+        help='None | search',
         default=None
     )
     return parser.parse_args()

--- a/etl/src/main.py
+++ b/etl/src/main.py
@@ -61,12 +61,12 @@ def main():
     logging.info('Loading configuration.')
     config = load_config()
     logging.info('Awaiting DBMS availability.')
-    await_url(config['arango']['arangoURL'])
+    await_url(config['dbms']['arangoURL'])
     logging.info('Awaiting DBMS connectivity.')
     conn = None
     while conn == None:
         try:
-            conn = Connection(**config['arango'])
+            conn = Connection(**config['dbms'])
         except:
             time.sleep(3)
     logging.info('Creating database.')
@@ -83,8 +83,10 @@ def main():
         logging.info('Populating YANG data.')
         populate_yang(db)
     if created or args.stage == 'search':
+        logging.info('Awaiting Search availability.')
+        await_url(config['search']['searchURL'])
         logging.info('Populating search database with parsed data.')
-        populate_search(db)
+        populate_search(db, config['search']['searchURL'])
     logging.info('ETL process complete!')
 
 def setup_args():

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,13 +1,12 @@
 FROM python:3-alpine
+WORKDIR /data/
 RUN pip install --no-cache-dir pip==18.0
 RUN pip install --no-cache-dir pipenv
-COPY src/Pipfile /data/Pipfile
-WORKDIR /data/
+COPY src/Pipfile Pipfile
 RUN apk add --no-cache --virtual .build-deps gcc musl-dev
 RUN pipenv --three install
 RUN apk del .build-deps gcc musl-dev
-COPY src/ /data/
-WORKDIR /data/
+COPY src/ .
 EXPOSE 80
 ENTRYPOINT [ "pipenv", "run" ]
 CMD [ "python", "runserver.py" ]


### PR DESCRIPTION
ETL will now await Search (Elasticsearch) availability and also has an entrypoint to restart ETL process at the search stage via a command like:
```bash
docker-compose run --rm etl python main.py --stage search
```
Doesn't cover exceptions creating Elasticsearch client etc. but helps mitigate/provides meantime solution.
Related to #24 