### PR TITLE
Set ElasticSearch discovery type to bypass bootstrap

### DIFF
--- a/docker-compose.https.yml
+++ b/docker-compose.https.yml
@@ -120,6 +120,7 @@ services:
       - cluster.name=tdm
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
     ulimits:
       memlock:
         soft: -1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       - cluster.name=tdm
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
     ulimits:
       memlock:
         soft: -1

--- a/start.sh
+++ b/start.sh
@@ -1,14 +1,39 @@
 #!/usr/bin/env bash
-COMPOSE_FILE=""
-case "$1" in
-    ""|"http")
-        COMPOSE_FILE=docker-compose.yml
-        ;;
-    "https")
-        COMPOSE_FILE=docker-compose.https.yml
+function check_sysctl() {
+    ES_RECC_MIN_MAX_MAP_COUNT=262144
+    ES_VM_MAX_MAP_COUNT=$(sysctl -n vm.max_map_count)
+    if [ "$ES_VM_MAX_MAP_COUNT" -lt "$ES_RECC_MIN_MAX_MAP_COUNT" ]; then
+        echo "vm.max_map_count=$ES_VM_MAX_MAP_COUNT is below ElasticSearch's recommended $ES_RECC_MIN_MAX_MAP_COUNT."
+        echo "Recommend running \"sysctl -w vm.max_map_count=$ES_RECC_MIN_MAX_MAP_COUNT\""
+        echo "Continuing will still work, but against recommended settings."
+        read -p "Press [Enter] to continue."
+    fi
+}
+
+function docker_up() {
+    COMPOSE_FILE=""
+    case "$1" in
+        ""|"http")
+            COMPOSE_FILE=docker-compose.yml
+            ;;
+        "https")
+            COMPOSE_FILE=docker-compose.https.yml
+            ;;
+        *)
+            echo $"Usage: $0 [http|https]"
+            exit 1
+    esac
+    docker-compose -f $COMPOSE_FILE up -d --build
+}
+
+UNAME="$(uname -s)"
+case "${UNAME}" in
+    Linux*)
+        check_sysctl
         ;;
     *)
-        echo $"Usage: $0 [http|https]"
-        exit 1
+        echo "Recommend running on Linux for production purposes."
+        echo "YMMV on Windows or MacOS."
+        sleep 5s
 esac
-docker-compose -f $COMPOSE_FILE up -d --build
+docker_up


### PR DESCRIPTION
Sets ElasticSearch `discovery.type=single-node` which effectively sets it to development mode.
Resolves #37 