### PR TITLE
Set pyang==1.7.5

### DIFF
--- a/etl/src/Pipfile
+++ b/etl/src/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 pyArango-upstream = {git = "https://github.com/tariqdaouda/pyArango.git", ref = "master"}
-pyang = "*"
+pyang = "==1.7.5"
 pysmi = "*"
 elasticsearch = "*"
 


### PR DESCRIPTION
Lock down `pyang` to 1.7.5 to prevent parsing issues with >=1.7.5. Resolves #51 