### PR TITLE
Infinite timeout for Search load ETL

### DIFF
--- a/etl/src/search.py
+++ b/etl/src/search.py
@@ -182,7 +182,8 @@ def populate_search_db(es, query_iterable, index, doc_type):
             es,
             iter_add_id(query_iterable),
             index=index,
-            doc_type=doc_type
+            doc_type=doc_type,
+            request_timeout=None
         ):
         action, result = result.popitem()
         doc_id = '/%s/%s/%s' % (index, doc_type, result['_id'])


### PR DESCRIPTION
Sets `request_timeout=None` for infinite time to finish loading DataPaths into ElasticSearch.

Fixes #87 